### PR TITLE
Add hide option to roll history

### DIFF
--- a/src/roll/roll-history-panel.js
+++ b/src/roll/roll-history-panel.js
@@ -15,64 +15,104 @@ import RollAgainstResult from './result/roll-against';
 
 import typeof RollOutcome from './result/roll-outcome';
 
-type RollHistoryProps = {
+type Props = {
     outcomes: Array<RollOutcome>;
     onRecordClosed: (number) => void;
 }
 
-export default function RollHistoryPanel(props: RollHistoryProps) {
-    const entries = props.outcomes.entries();
-    const result: Array<any> = [];
-    for (const entry of entries) {
-        const index: number = entry[0];
-        const outcome: any = entry[1];
+type State = {
+    hidden: boolean
+}
 
-        if (outcome.mode === 'count-hits') {
-            (outcome: CountHitsResult);
-            result.push(
-                <CountHitsRecord key={index}
-                                 recordKey={index}
-                                 onClose={props.onRecordClosed}
-                                 outcome={outcome} />
-            );
+export default class RollHistoryPanel extends Component<Props, State> {
+    handleHide: Function;
+    handleShow: Function;
+
+    constructor(props: Props) {
+        super(props);
+
+        this.state = { hidden: false }
+
+        this.handleHide = this.handleHide.bind(this);
+        this.handleShow = this.handleShow.bind(this);
+    }
+
+    handleHide() {
+        console.log("Handling hide");
+        this.setState({ hidden: true });
+    }
+    handleShow() {
+        console.log("Handling show");
+        this.setState({ hidden: false });
+    }
+
+    render() {
+        if (this.props.outcomes.length === 0) {
+            return <span id='roll-history-panel' />
         }
-        else if (outcome.mode === 'roll-against') {
-            (outcome: RollAgainstResult);
-            result.push(
-                <RollAgainstRecord key={index}
+        
+        const entries = this.props.outcomes.entries();
+        const header = (
+            <span class="roll-history-panel-header">
+                <b>Roll results</b> (
+                {
+                    this.state.hidden ?
+                    <a href="#" onClick={this.handleShow}>show</a>
+                    :
+                    <a href="#" onClick={this.handleHide}>hide</a>
+                })
+            </span>
+        );
+        if (this.state.hidden) {
+            return <Panel id="roll-history-panel"
+                          header={header}
+                          bsStyle="info" />
+        }
+
+        const result: Array<any> = [];
+        for (const entry of entries) {
+            const index: number = entry[0];
+            const outcome: any = entry[1];
+
+            if (outcome.mode === 'count-hits') {
+                (outcome: CountHitsResult);
+                result.push(
+                    <CountHitsRecord key={index}
+                                     recordKey={index}
+                                     onClose={this.props.onRecordClosed}
+                                     outcome={outcome} />
+                );
+            }
+            else if (outcome.mode === 'roll-against') {
+                (outcome: RollAgainstResult);
+                result.push(
+                    <RollAgainstRecord key={index}
+                                       recordKey={index}
+                                       onClose={this.props.onRecordClosed}
+                                       outcome={outcome} />
+                );
+            }
+            else if (outcome.mode === 'test-for') {
+                (outcome: TestForResult);
+                result.push(
+                    <TestForRecord key={index}
                                    recordKey={index}
-                                   onClose={props.onRecordClosed}
+                                   onClose={this.props.onRecordClosed}
                                    outcome={outcome} />
-            );
+                );
+            }
+            else if (outcome.mode === 'extended') {
+            }
+            else {
+            }
         }
-        else if (outcome.mode === 'test-for') {
-            (outcome: TestForResult);
-            result.push(
-                <TestForRecord key={index}
-                               recordKey={index}
-                               onClose={props.onRecordClosed}
-                               outcome={outcome} />
-            );
-        }
-        else if (outcome.mode === 'extended') {
-        }
-        else {
-        }
+
+        return (
+            <Panel id="roll-history-panel"
+                   header={header}
+                   bsStyle="info">
+                {result}
+            </Panel>
+        )
     }
-
-    if (result.length === 0) {
-        return <span id='roll-history-panel' />
-    }
-
-    const header = (
-        <h1>Roll results</h1>
-    );
-
-    return (
-        <Panel id="roll-history-panel"
-               header={header}
-               bsStyle="info">
-            {result}
-        </Panel>
-    )
 }


### PR DESCRIPTION
Now there's a [hide](#) link in the roll results panel. It compresses the panel down.

![2017-11-06-105413_801x434_scrot](https://user-images.githubusercontent.com/1468114/32449932-e1bf89ca-c2e0-11e7-886a-38b8722d81d1.png)
