### PR TITLE
Fix typo; slightly improve width

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -45,7 +45,7 @@
 
 .App-wide-container {
     margin: 1em auto 1em;
-    width: 98%;
+    max-width: 98%;
 }
 
 @media all and (min-width: 576px) {

--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ export default class App extends Component<{}> {
                 <header className="App-header">
                     <h1 className="App-title">Shadowroller</h1>
                 </header>
-                <div className="App-container">
+                <div className="App-wide-container">
                     <RollMenu />
                 </div>
             </div>


### PR DESCRIPTION
I was using `width` instead of `max-width` and had been missing a CSS class.

The main component should now be 10 pixels wider or so on desktops, I guess.