### PR TITLE
Math

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,10 +6,6 @@
   text-align: center;
 }
 
-.App-container {
-    display: flex;
-}
-
 /* Default:  half size title. */
 .App-header {
   background-color: #222;
@@ -73,13 +69,9 @@
     }
 }
 
-.numeric-input {
-    width: 4.5em !important;
-    padding-right: 4px !important;
-}
-
 .menu-label {
     font-size: 1.2em;
+    margin-bottom: 0px;
     padding-left: 10px;
     padding-right: 10px;
 }

--- a/src/components/numeric-input.css
+++ b/src/components/numeric-input.css
@@ -3,9 +3,8 @@
     padding-right: 4px !important;
 }
 
-.numeric-input-group {
-    display: inline;
-    align-self: center !important;
+.form-group {
+    margin-bottom: 0px !important;
 }
 
 .numeric-input-calculator {

--- a/src/components/numeric-input.css
+++ b/src/components/numeric-input.css
@@ -1,0 +1,21 @@
+.numeric-input {
+    width: 9em !important;
+    padding-right: 4px !important;
+}
+
+.numeric-input-group {
+    display: inline;
+    align-self: center !important;
+}
+
+.numeric-input-calculator {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 1.6em !important;
+    font-weight: 200 !important;
+    padding-bottom: 2px !important;
+    font-stretch: expanded !important;
+}
+
+.numeric-input-suffix {
+    font-family: monospace;
+}

--- a/src/components/numeric-input.js
+++ b/src/components/numeric-input.js
@@ -1,23 +1,190 @@
 // @flow
 
-import React from 'react';
+import './numeric-input.css';
 
-import { FormControl } from 'react-bootstrap';
+import * as React from 'react';
+
+import {
+    FormGroup, InputGroup,
+    FormControl, Button, Glyphicon
+} from 'react-bootstrap';
+
+import { Parser, evaluate } from '../math';
 
 type Props = {
+    controlId: string;
     onSelect: (?number) => void;
-    value?: number | string;
-    min?: number;
-    max?: number;
 };
 
+type RoundingMode = "up" | "down";
+
+type State = {
+    isExpression: boolean;
+    errorPos: ?number;
+    text: string;
+    value: ?number;
+    roundingMode: RoundingMode;
+}
+
+const CALCULATOR = "🖩";
+
+export default class NumericInput extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props);
+        this.state = {
+            isExpression: false,
+            errorPos: null,
+            text: "",
+            value: null,
+            roundingMode: "up",
+        };
+    }
+    handleInputEvent = (event: SyntheticInputEvent<HTMLInputElement>) => {
+        console.log("Input event: ", event.target);
+        // Evaluate the text.
+        if (event.target.value == null) {
+            console.log("It's null???");
+            this.props.onSelect(null);
+            this.setState({
+                text: "",
+                value: null,
+                errorPos: null,
+                isExpression: false
+            });
+        }
+        const parser = new Parser(event.target.value);
+        const expr = parser.expression();
+        console.log("Parsed expression: ", expr);
+        if (expr == null) {
+            const errorPos = parser.position();
+            this.props.onSelect(null);
+            this.setState({
+                text: event.target.value,
+                value: null,
+                errorPos,
+                isExpression: true
+            });
+        }
+        else {
+            const value = evaluate(expr);
+            console.log("Eval'd expression:", value);
+            if (isNaN(value)) {
+                const errorPos = parser.position();
+                this.props.onSelect(null);
+                this.setState({
+                    text: event.target.value,
+                    errorPos,
+                    value: null,
+                    isExpression: true
+                });
+            }
+            else {
+                // If it's not exact, dispatch the rounded.
+                if (!Number.isInteger(value)) {
+                    const rounded = this.state.roroundingMode === 'up' ?
+                        Math.ceil(value) : Math.floor(value);
+                    this.props.onSelect(rounded);
+                }
+                else {
+                    this.props.onSelect(value);
+                }
+                this.setState({
+                    text: event.target.value,
+                    value,
+                    errorPos: null,
+                    isExpression: expr.type !== 'number'
+                });
+
+            }
+        }
+    }
+
+    handleRoundModeChange = (event: SyntheticInputEvent<HTMLButtonElement>) => {
+        this.setState({
+            roundingMode: this.state.roundingMode === 'up' ?
+                "down" : "up"
+        });
+    }
+
+    render() {
+        console.log("Rendering text ", this.state.text);
+        console.log("Rendering value ", this.state.value);
+        const value = this.state.value;
+
+        // If we have a typo'd expression.
+        const invalid = this.state.isExpression && value == null;
+
+        let validationState: ?string = null;
+        let suffix: React.Node = "";
+        let extra: React.Node = "";
+
+        if (invalid) {
+            validationState = "error";
+            suffix = (
+                <InputGroup.Addon className="numeric-input-suffix">
+                    --
+                </InputGroup.Addon>
+            );
+            extra = (
+                <InputGroup.Addon>
+                    <abbr title="Typo location">
+                        @{this.state.errorPos || "?"}
+                    </abbr>
+                </InputGroup.Addon>
+            );
+        }
+        else if (value != null && this.state.isExpression) {
+            suffix = (
+                <InputGroup.Addon className="numeric-input-suffix">
+                    {value}
+                </InputGroup.Addon>
+            );
+            if (!Number.isInteger(value)) {
+                const icon = this.state.roundmroundingMode === "up" ?
+                    "arrow-up" : "arrow-down";
+                const rounded = this.state.roundingMode === 'up' ?
+                    Math.ceil(value) : Math.floor(value);
+                suffix = (
+                    <InputGroup.Addon className="numeric-input-suffix">
+                        {rounded}
+                    </InputGroup.Addon>
+                );
+                extra = (
+                    <InputGroup.Button>
+                        <Button onClick={this.handleRoundModeChange}>
+                            <Glyphicon icon={icon} />
+                        </Button>
+                    </InputGroup.Button>
+                )
+            }
+        }
+
+        return (
+            <FormGroup controlId={this.props.controlId}
+                       validationState={validationState}
+                       className="numeric-input-form-group">
+                <InputGroup className="numeric-input-group">
+                    <InputGroup.Addon className="numeric-input-caluclator">
+                        {CALCULATOR}
+                    </InputGroup.Addon>
+                    <FormControl className="numeric-input"
+                                 type="text"
+                                 inputMode="numeric"
+                                 value={this.state.text}
+                                 onChange={this.handleInputEvent} />
+                    {suffix}
+                    {extra}
+                </InputGroup>
+            </FormGroup>
+        );
+    }
+}
+
 /** Number-oriented input. */
-export default function NumericInput(props: Props) {
+export function NsumericInput(props: Props) {
     function handleInputEvent(event: SyntheticInputEvent<HTMLInputElement>) {
         const value: number = parseInt(event.target.value, 10);
-        if (isNaN(value)
-                || (props.min != null && value < props.min)
-                || (props.max != null && value > props.max)) {
+        if (isNaN(value)) {
             props.onSelect(null);
         }
         else {
@@ -31,9 +198,15 @@ export default function NumericInput(props: Props) {
     }
 
     return (
-        <FormControl className="numeric-input"
-                     type="number"
-                     value={value}
-                     onChange={handleInputEvent} />
+        <InputGroup className="numeric-input-group">
+            <InputGroup.Addon className="numeric-input-calculator">
+                {CALCULATOR}
+            </InputGroup.Addon>
+            <FormControl className="numeric-input"
+                         type="number"
+                         value={value}
+                         onChange={handleInputEvent} />
+            {""}
+        </InputGroup>
     );
 }

--- a/src/math/index.js
+++ b/src/math/index.js
@@ -1,0 +1,59 @@
+// @flow
+
+/** Binary operator, i.e. `+`, `-`, `*`, etc. */
+export type BinOp =
+| "+"
+| "-"
+| "*"
+| "/"
+| "^"
+;
+
+/** Unary operator: negative and positive */
+export type UnaryOp =
+| "-"
+| "+"
+;
+
+/**  */
+export type RoundingMode =
+| "up"
+| "down"
+;
+
+export type Expression =
+| { type: "number", value: number }
+| { type: "binOp", op: BinOp, left: Expression, right: Expression }
+| { type: "unaryOp", op: UnaryOp, expr: Expression }
+;
+
+export type MinPower = 0;
+export type AddSubPower = 1;
+export type MulDivPower = 2;
+export type ExpPower = 3;
+export type ParensPower = 4;
+
+export type BindingPower =
+| MinPower
+| AddSubPower
+| MulDivPower
+| ExpPower
+| ParensPower
+;
+
+export const CALCULATOR_CHAR = "🖩";
+
+export function powerOf(symbol: string): BindingPower {
+    switch (symbol) {
+        case '+': case '-':
+            return (1: AddSubPower);
+        case '*': case '/':
+            return (2: MulDivPower);
+        case '^':
+            return (3: ExpPower);
+        case '(': case ')':
+            return (4: ParensPower);
+        default:
+            return (0: MinPower);
+    }
+}

--- a/src/math/index.js
+++ b/src/math/index.js
@@ -57,3 +57,38 @@ export function powerOf(symbol: string): BindingPower {
             return (0: MinPower);
     }
 }
+
+export function evaluate(expr: Expression): number {
+    switch (expr.type) {
+        case 'number':
+            return expr.value;
+        case 'unaryOp':
+            switch (expr.op) {
+                case '+':
+                    return evaluate(expr.expr);
+                case '-':
+                    return -1 * evaluate(expr.expr);
+                default:
+                    return NaN;
+            }
+        case 'binOp':
+            switch (expr.op) {
+                case '+':
+                    return evaluate(expr.left) + evaluate(expr.right);
+                case '-':
+                    return evaluate(expr.left) - evaluate(expr.right);
+                case '*':
+                    return evaluate(expr.left) * evaluate(expr.right);
+                case '/':
+                    return evaluate(expr.left) / evaluate(expr.right);
+                case '^':
+                    return Math.pow(evaluate(expr.left), evaluate(expr.right));
+                default:
+                    return NaN;
+            }
+        default:
+            return NaN;
+    }
+}
+
+export {  Parser } from './parse';

--- a/src/math/parse.js
+++ b/src/math/parse.js
@@ -1,18 +1,15 @@
 // @flow
-
-import type {
-    Expression, BinOp, UnaryOp,
-    BindingPower, MinPower
-} from '.';
+import type { Expression, BindingPower, MinPower } from '.';
 import { powerOf } from '.';
 import type { Token } from './tokenize';
 import Tokenizer from './tokenize';
 
+// eslint-disable-next-line no-use-before-define
 type PrefixParser = (parser: Parser, current: Token) => ?Expression;
 
 const PREFIX_PARSERS: { [string]: PrefixParser } = {
+    // eslint-disable-next-line no-use-before-define
     '(': (parser: Parser, current: Token) => {
-        console.log("Parsing (");
         // Grab expression within parens.
         const inner = parser.expression();
         if (inner == null) { return null };
@@ -24,14 +21,15 @@ const PREFIX_PARSERS: { [string]: PrefixParser } = {
         else if (ending.value !== ')') {
             return null;
         }
-        console.log("Infix parsed: ", inner);
         return inner;
     },
+    // eslint-disable-next-line no-use-before-define
     '-': (parser: Parser, current: Token) => {
         const inner = parser.expression();
         if (inner == null) { return null; }
         return { type: "unaryOp", op: "-", expr: inner };
     },
+    // eslint-disable-next-line no-use-before-define
     '+': (parser: Parser, current: Token) => {
         const inner = parser.expression();
         if (inner == null) { return null; }
@@ -51,14 +49,12 @@ function isInfixChar(char: string): boolean {
     }
 }
 
+// eslint-disable-next-line no-use-before-define
 function parseInfix(parser: Parser, left: Expression, symbol: string): ?Expression {
-    console.log("Parsing infix: left=", left, "right=", symbol);
     switch (symbol) {
         // Treat an infix left paren as a multiplication expression.
         case '(': {
-            console.log("Parsing inner");
             const inner = parser.expression();
-            console.log("Done with inner");
             if (inner == null) { return null; }
             const close = parser.token();
             if (close == null || close.type !== "symbol" || close.value !== ')') {
@@ -116,30 +112,25 @@ export class Parser {
         let current = this.token();
         // If we're asking for an expression when we're done, we have a problem.
         if (current == null || current.type === 'done') {
-            console.log("No more expressions");
             return null;
         }
         let left: Expression;
         // If we got a number, return a number.
         if (current.type === 'number') {
-            console.log("Left is number");
             left =  { type: 'number', value: current.value };
         }
         else {
             // Otherwise, look up the prefix parser we need.
             const prefixParser = PREFIX_PARSERS[current.value];
             if (prefixParser == null) {
-                console.log("No prefix parser found");
                 return null;
             }
             // Grab the prefix expression. If null, we have a problem.
             const parsedLeft = prefixParser(this, current);
             if (parsedLeft == null) { return null; }
-            console.log("Prefix-parsed left: ", parsedLeft);
             left = parsedLeft;
         }
         while (power <= this.currentPower()) {
-            console.log("Preparing infix");
             // We might have an infix char after this prefix expr.
             const infixToken = this.peek();
             // If we've reached the end, then it was just that expression we parsed.
@@ -148,14 +139,12 @@ export class Parser {
             else if (infixToken.type === 'number') { return null; }
             // If it's not an infix char, don't use it.
             if (!isInfixChar(infixToken.value)) {
-                console.log("Found a not infix token ", infixToken);
                 break;
             }
             // Confirm taking the token.
             this.token();
             const parsed = parseInfix(this, left, infixToken.value);
             if (parsed == null) { return null; }
-            console.log("Parsed infix: ", parsed);
             left = parsed;
         }
         return left;

--- a/src/math/parse.js
+++ b/src/math/parse.js
@@ -1,0 +1,150 @@
+// @flow
+
+import type {
+    Expression, BinOp, UnaryOp,
+    BindingPower, MinPower
+} from '.';
+import { powerOf } from '.';
+import type { Token } from './tokenize';
+import Tokenizer from './tokenize';
+
+type PrefixParser = (parser: Parser, current: Token) => ?Expression;
+
+const PREFIX_PARSERS: { [string]: PrefixParser } = {
+    '(': (parser: Parser, current: Token) => {
+        // Grab expression within parens.
+        const inner = parser.expression();
+        if (inner == null) { return null };
+        const ending = parser.token();
+        // Expect a `)` after an expression.
+        if (ending == null || ending.type !== 'symbol') {
+            return null;
+        }
+        else if (ending.value !== ')') {
+            return null;
+        }
+        return inner;
+    },
+    '-': (parser: Parser, current: Token) => {
+        const inner = parser.expression();
+        if (inner == null) { return null; }
+        return { type: "unaryOp", op: "-", expr: inner };
+    },
+    '+': (parser: Parser, current: Token) => {
+        const inner = parser.expression();
+        if (inner == null) { return null; }
+        return { type: "unaryOp", op: "+", expr: inner };
+    }
+};
+
+function isInfixChar(char: string): boolean {
+    switch (char) {
+        case '+': case '-':
+        case '*': case '/':
+        case '^':
+        case '(': // We can parse `(` infix as multiplication.
+            return true;
+        default:
+            return false;
+    }
+}
+
+function parseInfix(parser: Parser, left: Expression, symbol: string): ?Expression {
+    switch (symbol) {
+        // Treat an infix left paren as a multiplication expression.
+        case '(': {
+            const inner = parser.expression();
+            if (inner == null) { return null; }
+            const close = parser.token();
+            if (close == null || close.type !== "symbol" || close.value !== ')') {
+                return null;
+            }
+            return { type: "binOp", op: "*", left, right: inner };
+        }
+        case '+': case '-': case '*': case '/': {
+            const power = powerOf(symbol);
+            const right = parser.expression(power);
+            if (right == null) { return null; }
+            return { type: "binOp", op: symbol, left, right: right };
+        }
+        case '^': {
+            const power = powerOf(symbol);
+            const right = parser.expression(power);
+            if (right == null) { return null; }
+            return { type: "binOp", op: '^', left, right: right };
+        }
+        default:
+            return null;
+    }
+}
+
+class Parser {
+    tokenizer: Tokenizer;
+    lookahead: ?Token;
+
+    constructor(text: string) {
+        this.tokenizer = new Tokenizer(text);
+        this.lookahead = null;
+    }
+
+    peek = (): ?Token => {
+        if (this.lookahead == null) {
+            const next = this.tokenizer.next();
+            if (next == null) { return null; }
+            this.lookahead = next;
+        }
+        return this.lookahead;
+    }
+
+    token = (): ?Token => {
+        if (this.lookahead == null) {
+            return this.tokenizer.next();
+        }
+        else {
+            const next = this.lookahead;
+            this.lookahead = null;
+            return next;
+        }
+    }
+
+    expression = (power: BindingPower = 0): ?Expression => {
+        let current = this.token();
+        // If we're asking for an expression when we're done, we have a problem.
+        if (current == null || current.type === 'done') { return null; }
+        // If we got a number, return a number.
+        if (current.type === 'number') {
+            return { type: 'number', value: current.value };
+        }
+        // Otherwise, look up the prefix parser we need.
+        const prefixParser = PREFIX_PARSERS[current.value];
+        if (prefixParser == null) { return null; }
+        // Grab the prefix expression. If null, we have a problem.
+        let left = prefixParser(this, current);
+        if (left == null) { return null; }
+        while (power <= this.currentPower()) {
+            // We might have an infix char after this prefix expr.
+            const infixToken = this.token();
+            // If we can't get a token now, we have a problem.
+            if (infixToken == null || infixToken.type === 'number') { return null; }
+            // If we've reached the end, then it was just that expression we parsed.
+            if (infixToken.type === 'done') { return left; }
+            // If it's not an infix char, don't use it.
+            if (!isInfixChar(infixToken.value)) {
+                return null;
+            }
+            left = parseInfix(this, left, infixToken.value);
+            if (left == null) { return null; }
+        }
+    }
+
+    currentPower = (): BindingPower => {
+        const nextToken = this.peek();
+        if (nextToken == null ||
+            nextToken.type !== 'symbol') {
+            return (0: MinPower);
+        }
+        else {
+            return powerOf(nextToken.value);
+        }
+    }
+}

--- a/src/math/tokenize.js
+++ b/src/math/tokenize.js
@@ -17,6 +17,7 @@ export default class Tokenizer {
 
     next = (): ?Token => {
         if (this.position >= this.text.length) {
+            console.log("Done parsing");
             return { type: "done" };
         }
         let nextChar: string = this.text[this.position];
@@ -28,12 +29,16 @@ export default class Tokenizer {
         }
         // It's a number.
         if (!isNaN(nextChar)) {
+            console.log("Parsing a number");
             const numberChars: string[] = [nextChar];
             // Keep taking number characters until we hit a non-
             // number or EOF.
-            while (this.position < this.text.length) {
-                const peeked = this.text[this.position + 1];
-                if (!isNaN(peeked) || peeked === '.') {
+            while (this.position < this.text.length + 1) {
+                const peeked = this.text[this.position];
+                if (peeked == null) {
+                    break;
+                }
+                else if (!isNaN(peeked) || peeked === '.') {
                     // If we have another number char (a 2+ digit number),
                     // append it to the array.
                     numberChars.push(peeked);
@@ -48,9 +53,10 @@ export default class Tokenizer {
                     break;
                 }
             }
-            const numberText: string = numberChars.join();
+            const numberText: string = numberChars.join("");
             const numberValue = parseFloat(numberText);
             if (!isNaN(numberValue)) {
+                console.log("Parsed number ", numberValue);
                 return { type: "number", value: numberValue };
             }
             else {
@@ -62,6 +68,7 @@ export default class Tokenizer {
             case '+': case '-':
             case '*': case '/':
             case '^':
+                console.log("Parsing a symbol: ", nextChar);
                 return { type: "symbol", value: nextChar };
             default:
                 return null;

--- a/src/math/tokenize.js
+++ b/src/math/tokenize.js
@@ -17,7 +17,6 @@ export default class Tokenizer {
 
     next = (): ?Token => {
         if (this.position >= this.text.length) {
-            console.log("Done parsing");
             return { type: "done" };
         }
         let nextChar: string = this.text[this.position];
@@ -29,7 +28,6 @@ export default class Tokenizer {
         }
         // It's a number.
         if (!isNaN(nextChar)) {
-            console.log("Parsing a number");
             const numberChars: string[] = [nextChar];
             // Keep taking number characters until we hit a non-
             // number or EOF.
@@ -56,7 +54,6 @@ export default class Tokenizer {
             const numberText: string = numberChars.join("");
             const numberValue = parseFloat(numberText);
             if (!isNaN(numberValue)) {
-                console.log("Parsed number ", numberValue);
                 return { type: "number", value: numberValue };
             }
             else {
@@ -68,7 +65,6 @@ export default class Tokenizer {
             case '+': case '-':
             case '*': case '/':
             case '^':
-                console.log("Parsing a symbol: ", nextChar);
                 return { type: "symbol", value: nextChar };
             default:
                 return null;

--- a/src/math/tokenize.js
+++ b/src/math/tokenize.js
@@ -1,0 +1,70 @@
+// @flow
+
+export type Token =
+| { type: "done" }
+| { type: "symbol", value: string }
+| { type: "number", value: number }
+;
+
+export default class Tokenizer {
+    text: string;
+    position: number;
+
+    constructor(text: string) {
+        this.text = text;
+        this.position = 0;
+    }
+
+    next = (): ?Token => {
+        if (this.position >= this.text.length) {
+            return { type: "done" };
+        }
+        let nextChar: string = this.text[this.position];
+        this.position++;
+        // Skip over spaces at the start of `next()`.
+        while (nextChar === ' ' || nextChar === '\t') {
+            nextChar = this.text[this.position];
+            this.position++;
+        }
+        // It's a number.
+        if (!isNaN(nextChar)) {
+            const numberChars: string[] = [nextChar];
+            // Keep taking number characters until we hit a non-
+            // number or EOF.
+            while (this.position < this.text.length) {
+                const peeked = this.text[this.position + 1];
+                if (!isNaN(peeked) || peeked === '.') {
+                    // If we have another number char (a 2+ digit number),
+                    // append it to the array.
+                    numberChars.push(peeked);
+                    this.position++;
+                }
+                // Ignore underscores or commas used as separators.
+                else if (peeked === '_' || peeked === ',') {
+                    this.position++;
+                }
+                else {
+                    // Otherwise, we have a character that's not a number.
+                    break;
+                }
+            }
+            const numberText: string = numberChars.join();
+            const numberValue = parseFloat(numberText);
+            if (!isNaN(numberValue)) {
+                return { type: "number", value: numberValue };
+            }
+            else {
+                return null;
+            }
+        }
+        switch (nextChar) {
+            case '(':  case ')':
+            case '+': case '-':
+            case '*': case '/':
+            case '^':
+                return { type: "symbol", value: nextChar };
+            default:
+                return null;
+        }
+    }
+}

--- a/src/roll/components/random-loading-label.css
+++ b/src/roll/components/random-loading-label.css
@@ -22,3 +22,7 @@
   80% {content:'\2684';}
   100% {content:'\2685';}
 }
+
+.monospace {
+    font-family: monospace;
+}

--- a/src/roll/components/random-loading-label.js
+++ b/src/roll/components/random-loading-label.js
@@ -2,7 +2,7 @@
 
 import './random-loading-label.css';
 
-import React, { Component } from 'react';
+import * as React from 'react';
 import { ControlLabel } from 'react-bootstrap';
 
 import { connect } from 'react-redux';
@@ -12,10 +12,16 @@ import type { AppState, DispatchFn, GetStateFn } from '../../state';
 import * as rollActions from '../actions';
 import pickRandom from '../../util/pick-random';
 
-const loadingFlavorText: string[] = [
+const loadingFlavorText: React.Node[] = [
     "Getting all the best rolls",
 
-    "Monkey tacos! I'm so random",
+    <span>
+        Monkey tacos! I'm{" "}
+        <span className="monospace">
+            so
+        </span>{" "}
+        random
+    </span>,
     "Something something randomizing",
     "Potato potato shadow run stuff",
 
@@ -23,7 +29,15 @@ const loadingFlavorText: string[] = [
     "Setting up the horse races",
     "Not fixing the horse races",
     "Don't get your locks melted off",
-    "Fetching b0ss a critical glitch",
+    <span>
+        Fetching{" "}
+        <span className="monospace">
+            b0ss
+        </span>{" "}
+        a critical glitch
+    </span>,
+    "Getting roll data from some guy on JackPoint",
+    "Escorting an Aztech package full of rolls",
 
     "Preconfiguring the glitches",
     "Asking the dragons for rolls",
@@ -40,7 +54,7 @@ const loadingFlavorText: string[] = [
     "Here, have some glitches",
 ];
 
-const loadedFlavorText: string[] = [
+const loadedFlavorText: React.Node[] = [
     "Rolls from random.org",
     "Rolls from random.org",
     "Rolls from random.org",
@@ -57,30 +71,33 @@ const loadedFlavorText: string[] = [
     "Go get 'em, chummer",
 ];
 
-const localRequiredFlavorText: string[] = [
+const localRequiredFlavorText: React.Node[] = [
     "Can't access random.org",
     "random.org is offline",
     "Can't find random.org on the Matrix",
     "Too much noise to access random.org",
-    "Unable to find random.org's host",
+    "Unable to find random.org's Host",
 ];
 
-const localLoadingFlavorText: string[] = [
+const localLoadingFlavorText: React.Node[] = [
     "Getting randoness from your browser",
     "Hope your browser has good RNG",
     "Your browser better be random enough, chummer",
 ];
 
-const localLoadedFlavorText: string[] = [
-    "Rolls from Random.next()",
+const localLoadedFlavorText: React.Node[] = [
+    <span>
+        Rolls from{" "}
+        <span className="monospace">
+            Random.next()
+        </span>
+    </span>,
     "Rolls from your browser",
-    "Pseudorandom rolls from your browser",
-    "Pseudorandom rolls from your browser",
     "Pseudorandom rolls from your browser",
     "Possibly-compromised rolls from your browser",
 
     "Rolling in offline mode",
-    "Rolling without wireless bonus",
+    "Rolling without Wireless bonus",
 ];
 
 type Props = {|
@@ -91,7 +108,7 @@ type Props = {|
     isLocal: boolean,
 |};
 
-class RandomLoadingLabel extends Component<Props> {
+class RandomLoadingLabel extends React.Component<Props> {
     shouldComponentUpdate(nextProps: Props) {
         return nextProps.bufferLoadState !== this.props.bufferLoadState
             || nextProps.isLocal !== this.props.isLocal;

--- a/src/roll/containers/options/roll-against.js
+++ b/src/roll/containers/options/roll-against.js
@@ -16,9 +16,8 @@ export default function RollAgainstRollOptions(props: Props) {
     return (
         <FormGroup controlId="roll-input-roll-against"
                    className="roll-input-options">
-            <NumericInput min={0} max={99}
-                          value={props.value || ''}
-                          onSelect={props.onChange} />
+            <NumericInput controlId="roll-input-roll-against"
+                onSelect={props.onChange} />
             <ControlLabel className="menu-label">
                 dice
             </ControlLabel>

--- a/src/roll/containers/options/roll-against.js
+++ b/src/roll/containers/options/roll-against.js
@@ -17,6 +17,7 @@ export default function RollAgainstRollOptions(props: Props) {
         <FormGroup controlId="roll-input-roll-against"
                    className="roll-input-options">
             <NumericInput controlId="roll-input-roll-against"
+                min={1} max={100}
                 onSelect={props.onChange} />
             <ControlLabel className="menu-label">
                 dice

--- a/src/roll/containers/options/test-for.js
+++ b/src/roll/containers/options/test-for.js
@@ -16,9 +16,8 @@ export default function TestForRollOptions(props: Props) {
     return (
         <FormGroup controlId="roll-input-test-for"
                    className="roll-input-options">
-            <NumericInput min={0} max={99}
-                          value={props.value || ''}
-                          onSelect={props.onChange} />
+            <NumericInput controlId="roll-input-test-for"
+                onSelect={props.onChange} />
             <ControlLabel className="menu-label">
                 hits
             </ControlLabel>

--- a/src/roll/containers/roll-input-panel.css
+++ b/src/roll/containers/roll-input-panel.css
@@ -1,21 +1,21 @@
 #roll-input-panel-form {
     display: flex;
     flex-direction: column;
-    align-content: center;
+    align-items: center;
     justify-content: space-around;
 }
 
 @media all and (min-width: 768px) {
     #roll-input-panel-form {
         flex-direction: row;
-        align-items: baseline;
+        align-items: center;
         flex-wrap: wrap;
     }
 }
 
 #roll-input-dice-group {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     margin-bottom: 15px;
     margin-left: auto;
     margin-right: auto;
@@ -43,7 +43,7 @@
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
-    align-items: baseline;
+    align-items: center;
     margin-bottom: 15px;
     margin-left: auto;
     margin-right: auto;

--- a/src/roll/containers/roll-input-panel.js
+++ b/src/roll/containers/roll-input-panel.js
@@ -48,7 +48,12 @@ class RollInputPanel extends React.Component<Props> {
     }
 
     handleDiceChange = (dice: ?number) => {
-        this.props.dispatch(rollActions.setDiceCount(dice));
+        if (dice != null && dice < 99 && dice > 0) {
+            this.props.dispatch(rollActions.setDiceCount(dice));
+        }
+        else {
+            this.props.dispatch(rollActions.setDiceCount(null));
+        }
     }
 
     handleRollModeSelect = (mode: RollMode) => {
@@ -120,8 +125,7 @@ class RollInputPanel extends React.Component<Props> {
                         <ControlLabel className="menu-label">
                             Roll
                         </ControlLabel>
-                        <NumericInput min={0} max={99}
-                                      value={state.rollDice || ''}
+                        <NumericInput controlId="roll-input-dice"
                                       onSelect={this.handleDiceChange} />
                         <ControlLabel className="menu-label">
                             dice

--- a/src/roll/containers/roll-input-panel.js
+++ b/src/roll/containers/roll-input-panel.js
@@ -126,6 +126,7 @@ class RollInputPanel extends React.Component<Props> {
                             Roll
                         </ControlLabel>
                         <NumericInput controlId="roll-input-dice"
+                                      min={1} max={100}
                                       onSelect={this.handleDiceChange} />
                         <ControlLabel className="menu-label">
                             dice


### PR DESCRIPTION
- `NumericInput` supports arithmetic expressions like `+`, `-`, `*`, `/`, and parens
- Math parsing is done using Pratt parsing (TDOP), check out https://github.com/snirkimmington/protosnirk for an example.
- Putting an expression before parens can also multiply, i.e. `4(5)` will produce 20
- Numeric inputs will round their entire result if it's not an integer
- Values too high/low are indicated on the inputs (i.e. rolling less than 1 or more than 99 dice).
- Stuff is more aligned now. All hail `flexbox`.