### PR TITLE
Rewrite event records, add timestamps

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -105,6 +105,10 @@ export const defaultState: State = {
     historyFetch: "ready",
 };
 
+export function timeOf(event: Event): Date {
+    return new Date(event.id);
+}
+
 export function colorOf(event: Event): string {
     return event.source !== "local" ? srutil.hashedColor(event.source.id) : 'slategray';
 }

--- a/src/history-panel.js
+++ b/src/history-panel.js
@@ -28,18 +28,6 @@ const GAME_EMPTY_FLAVOR = [
     "Be the first one to roll!",
 ];
 
-function defaultHeight(event: Event.Event): number {
-    switch (event.ty) {
-        case "playerJoin": return 34;
-        case "roll": return 100;
-        case "rerollFailures":
-        case "edgeRoll":
-            return 120;
-        default:
-            return 34;
-    }
-}
-
 type RecordProps = {
     +event: ?Event.Event,
     +eventIx: number,
@@ -147,7 +135,7 @@ export function LoadingResultList({ playerID }: { playerID: ?string }) {
     }
 
     function setIndexHeight(height: number, index) {
-        if (itemSizes.current[index] == height) {
+        if (itemSizes.current[index] === height) {
             return;
         }
         itemSizes.current[index] = height;
@@ -165,7 +153,7 @@ export function LoadingResultList({ playerID }: { playerID: ?string }) {
             const event = data[index];
             return <EventRecord event={event} setHeight={setHeight} eventIx={index} style={style} />;
         }
-    }, [itemSizes, loadedAt]);
+    }, [loadedAt]);
 
     function loadMoreItems(oldestIx: number): ?Promise<void> {
         if (fetchingEvents || connection === "offline") {

--- a/src/humanTime.js
+++ b/src/humanTime.js
@@ -1,0 +1,54 @@
+// @flow
+
+import * as React from 'react';
+import styled from 'styled-components/macro';
+import type { StyledComponent } from 'styled-components';
+import * as UI from 'style';
+import theme from 'style/theme';
+
+const MINUTE = 60,
+      HOUR = MINUTE * 60,
+      DAY = HOUR * 24,
+      WEEK = DAY * 7;
+
+const HOUR_FORMAT = new Intl.DateTimeFormat(undefined, { timeStyle: "short" });
+const WEEK_DAY = new Intl.DateTimeFormat(undefined, { weekday: "long" });
+const MONTH_FORMAT = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+    timeStyle: "short", dateStyle: "medium"
+});
+
+export function since(ts: Date, now: Date = new Date()): string {
+    // Get delta of timestamps in seconds
+    const delta = Math.round((now.valueOf() - ts.valueOf()) / 1000);
+    if (delta < DAY) {
+        return HOUR_FORMAT.format(ts);
+    }
+    if (delta < 2 * DAY) {
+        return `Yesterday at ${HOUR_FORMAT.format(ts)}`;
+    }
+    if (delta < WEEK) {
+        return `${WEEK_DAY.format(ts)} at ${HOUR_FORMAT.format(ts)}`;
+    }
+    if (delta < 2 * WEEK) {
+        return `Last ${WEEK_DAY.format(ts)} at ${HOUR_FORMAT.format(ts)}`;
+    }
+    if (ts.getFullYear() == now.getFullYear()) {
+        return `${MONTH_FORMAT.format(ts)} at ${HOUR_FORMAT.format(ts)}`;
+    }
+    return DATE_FORMAT.format(ts);
+}
+
+const StyledSince: StyledComponent<{}, typeof theme> = styled.div`
+    white-space: nowrap;
+    font-size: 0.6rem;
+    line-height: 1rem;
+    filter: brightness(70%);
+    color: ${({theme}) => theme.colors.gray1};
+`;
+
+export function Since({ date }: { date: Date }) {
+    return (
+        <StyledSince>{since(date) ?? "At some point"}</StyledSince>
+    );
+}

--- a/src/humanTime.js
+++ b/src/humanTime.js
@@ -25,7 +25,7 @@ export function since(ts: Date, now: Date = new Date()): string {
         return HOUR_FORMAT.format(ts);
     }
     if (delta < 2 * DAY) {
-        return `Yesterday at ${HOUR_FORMAT.format(ts)}`;
+        return `Yesterday ${HOUR_FORMAT.format(ts)}`;
     }
     if (delta < WEEK) {
         return `${WEEK_DAY.format(ts)} at ${HOUR_FORMAT.format(ts)}`;

--- a/src/humanTime.js
+++ b/src/humanTime.js
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import styled from 'styled-components/macro';
 import type { StyledComponent } from 'styled-components';
-import * as UI from 'style';
 import theme from 'style/theme';
 
 const MINUTE = 60,
@@ -33,7 +32,7 @@ export function since(ts: Date, now: Date = new Date()): string {
     if (delta < 2 * WEEK) {
         return `Last ${WEEK_DAY.format(ts)} at ${HOUR_FORMAT.format(ts)}`;
     }
-    if (ts.getFullYear() == now.getFullYear()) {
+    if (ts.getFullYear() === now.getFullYear()) {
         return `${MONTH_FORMAT.format(ts)} at ${HOUR_FORMAT.format(ts)}`;
     }
     return DATE_FORMAT.format(ts);

--- a/src/index.css
+++ b/src/index.css
@@ -54,8 +54,8 @@ p {
 }
 @media all and (min-width: 768px) {
     .sr-die {
-        width: 2.5rem;
-        height: 2.5rem;
+        width: 2.45rem;
+        height: 2.45rem;
     }
 }
 

--- a/src/record/edgeRoll.js
+++ b/src/record/edgeRoll.js
@@ -3,20 +3,20 @@
 import * as React from 'react';
 import styled from 'styled-components/macro';
 import * as UI from 'style';
+import theme from 'style/theme';
 import * as dice from 'dice';
 import * as humanTime from 'humanTime';
+import * as icons from 'style/icon';
 import * as Roll from './rollComponents';
 
-import * as Game from 'game';
 import * as Event from 'event';
-import routes from 'routes';
-import * as srutil from 'srutil';
+import * as Game from 'game';
 import * as rollStats from 'rollStats';
 
 type Props = {
-    event: Event.Roll
+    +event: Event.EdgeRoll,
 }
-function RollRecordInner({ event }: Props, ref) {
+function EdgeRollRecord({ event }: Props, ref) {
     const game = React.useContext(Game.Ctx);
 
     const color = Event.colorOf(event);
@@ -28,15 +28,17 @@ function RollRecordInner({ event }: Props, ref) {
             <UI.HashColored id={event.source.id}>
                 {event.source.name}
             </UI.HashColored>
-            {` rolls`}
+            &nbsp;
+            <b>pushes the limit</b>
         </>
     ) : (
-        <>Rolled</>
+        <b>Pushed the limit</b>
     );
+
     const title = event.title ? (
         <>to <b>{event.title}</b></>
     ) : (
-        <>{event.dice.length} {event.dice.length == 1 ? "die" : "dice"}</>
+        <>on {event.rounds[0].length} {event.rounds[0].length == 1 ? "die" : "dice"}</>
     );
 
     return (
@@ -46,16 +48,16 @@ function RollRecordInner({ event }: Props, ref) {
                 <Roll.Results color={color} result={result} />
             </UI.FlexRow>
             <Roll.Scrollable>
-                <dice.List rolls={event.dice} />
-            </Roll.Scrollable>
-            <UI.FlexRow floatRight>
-                <humanTime.Since date={Event.timeOf(event)} />
+                <dice.List rolls={event.rounds[0]} />
                 <UI.FlexRow>
-                    {canModify &&
-                        <Roll.ActionsRow event={event} result={result} />}
+                    <Roll.Rounds icon={icons.faBolt} color={color}
+                                 rounds={event.rounds.slice(1)} />
                 </UI.FlexRow>
+            </Roll.Scrollable>
+            <UI.FlexRow>
+                <humanTime.Since date={Event.timeOf(event)} />
             </UI.FlexRow>
         </UI.FlexColumn>
     );
 }
-export const RollRecord = React.memo<Props>(React.forwardRef(RollRecordInner));
+export const EdgeRoll = React.memo<Props>(React.forwardRef(EdgeRollRecord));

--- a/src/record/edgeRoll.js
+++ b/src/record/edgeRoll.js
@@ -1,27 +1,21 @@
 // @flow
 
 import * as React from 'react';
-import styled from 'styled-components/macro';
 import * as UI from 'style';
-import theme from 'style/theme';
 import * as dice from 'dice';
 import * as humanTime from 'humanTime';
 import * as icons from 'style/icon';
 import * as Roll from './rollComponents';
 
 import * as Event from 'event';
-import * as Game from 'game';
 import * as rollStats from 'rollStats';
 
 type Props = {
     +event: Event.EdgeRoll,
 }
 function EdgeRollRecord({ event }: Props, ref) {
-    const game = React.useContext(Game.Ctx);
-
     const color = Event.colorOf(event);
     const result = rollStats.results(event);
-    const canModify = Event.canModify(event, game?.player?.id);
 
     const intro: React.Node = event.source !== "local" ? (
         <>
@@ -38,7 +32,7 @@ function EdgeRollRecord({ event }: Props, ref) {
     const title = event.title ? (
         <>to <b>{event.title}</b></>
     ) : (
-        <>on {event.rounds[0].length} {event.rounds[0].length == 1 ? "die" : "dice"}</>
+        <>on {event.rounds[0].length} {event.rounds[0].length === 1 ? "die" : "dice"}</>
     );
 
     return (

--- a/src/record/index.js
+++ b/src/record/index.js
@@ -14,14 +14,23 @@ type RecordProps = {
 const GUTTER_SIZE = 4;
 
 export const StyledRecord: StyledComponent<RecordProps> = styled(UI.FlexColumn).attrs(
-    props => ({
-        style: {
+    props => {
+        console.log("StyledRecord", props, props.style.height);
+        // So we get an initial height which we need to not pass through.
+        if (props.style.height == 69) {
+            delete props.style.height;
+            return {
+                ...props.style,
+            };
+        }
+        console.log(props.style)
+        const style = {
             ...props.style,
             height: props.style.height - GUTTER_SIZE,
             bottom: props.style.bottom - GUTTER_SIZE,
-        }
-    })
-)`
+        };
+        return { style };
+})`
     padding-left: 5px;
     ${({color}) =>
         `border-left: 5px solid ${color};`

--- a/src/record/index.js
+++ b/src/record/index.js
@@ -13,25 +13,18 @@ type RecordProps = {
 // Spacing between event records
 const GUTTER_SIZE = 4;
 
-export const StyledRecord: StyledComponent<RecordProps> = styled(UI.FlexColumn).attrs(
+export const StyledRecord: StyledComponent<RecordProps> = styled.div.attrs(
     props => {
-        console.log("StyledRecord", props, props.style.height);
-        // So we get an initial height which we need to not pass through.
-        if (props.style.height == 69) {
-            delete props.style.height;
-            return {
-                ...props.style,
-            };
-        }
-        console.log(props.style)
         const style = {
             ...props.style,
+            top: props.style.top + GUTTER_SIZE,
             height: props.style.height - GUTTER_SIZE,
-            bottom: props.style.bottom - GUTTER_SIZE,
         };
         return { style };
 })`
+    padding-bottom: 4px;
     padding-left: 5px;
+    padding-right: 2px;
     ${({color}) =>
         `border-left: 5px solid ${color};`
     }
@@ -40,3 +33,6 @@ export const StyledRecord: StyledComponent<RecordProps> = styled(UI.FlexColumn).
 
 export * from './roll';
 export * from './otherEvents';
+export { EdgeRoll } from './edgeRoll';
+export { Reroll } from './reroll';
+export { RollRecord as Roll } from './roll';

--- a/src/record/index.js
+++ b/src/record/index.js
@@ -1,7 +1,6 @@
 // @flow
 
 import styled from 'styled-components/macro';
-import * as UI from 'style';
 import type { StyledComponent } from 'styled-components';
 
 type RecordProps = {

--- a/src/record/otherEvents.js
+++ b/src/record/otherEvents.js
@@ -1,10 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import styled from 'styled-components/macro';
 import * as humanTime from 'humanTime';
-
 import * as UI from 'style';
+
 import * as Game from 'game';
 import * as Event from 'event';
 
@@ -31,7 +30,7 @@ export const PlayerJoin = React.memo<PlayerJoinProps>(React.forwardRef(function 
     );
 }), (prev, next) => prev.event.id === next.event.id);
 
-export const Loading = React.memo<{}>(React.forwardRef(function LoadingIndicator({}, ref) {
+export const Loading = React.memo<{}>(React.forwardRef(function LoadingIndicator(props, ref) {
     return (
         <span ref={ref}>Getting some rolls... <UI.DiceSpinner /></span>
     );

--- a/src/record/otherEvents.js
+++ b/src/record/otherEvents.js
@@ -2,31 +2,37 @@
 
 import * as React from 'react';
 import styled from 'styled-components/macro';
+import * as humanTime from 'humanTime';
 
 import * as UI from 'style';
 import * as Game from 'game';
 import * as Event from 'event';
 
-const CenteredSpan = styled.span`
-    margin: auto 0 auto 2px;
-`;
-
 type PlayerJoinProps = {
     +event: Event.PlayerJoin,
 };
-export const PlayerJoin = React.memo<PlayerJoinProps>(function PlayerJoin({ event }) {
+export const PlayerJoin = React.memo<PlayerJoinProps>(React.forwardRef(function PlayerJoin({ event }, ref) {
     const game = React.useContext(Game.Ctx);
 
     const name = <UI.PlayerName id={event.source.id} name={event.source.name} />
     return (
-        <CenteredSpan>
-            {name}{' joined '}{game?.gameID || "the game"}.
-        </CenteredSpan>
+        <UI.FlexColumn ref={ref}>
+            <UI.FlexRow>
+                <span style={{ lineHeight: '1.2' }}>
+                    {name}{' joined '}
+                    {game?.gameID != null ?
+                        <tt>{game.gameID}</tt> : "the game"}.
+                </span>
+            </UI.FlexRow>
+            <UI.FlexRow>
+                <humanTime.Since date={Event.timeOf(event)} />
+            </UI.FlexRow>
+        </UI.FlexColumn>
     );
-}, (prev, next) => prev.event.id === next.event.id);
+}), (prev, next) => prev.event.id === next.event.id);
 
-export const Loading = React.memo<{}>(function LoadingIndicator() {
+export const Loading = React.memo<{}>(React.forwardRef(function LoadingIndicator({}, ref) {
     return (
-        <span>Getting some rolls... <UI.DiceSpinner /></span>
+        <span ref={ref}>Getting some rolls... <UI.DiceSpinner /></span>
     );
-});
+}));

--- a/src/record/reroll.js
+++ b/src/record/reroll.js
@@ -3,20 +3,20 @@
 import * as React from 'react';
 import styled from 'styled-components/macro';
 import * as UI from 'style';
+import theme from 'style/theme';
 import * as dice from 'dice';
 import * as humanTime from 'humanTime';
+import * as icons from 'style/icon';
 import * as Roll from './rollComponents';
 
-import * as Game from 'game';
 import * as Event from 'event';
-import routes from 'routes';
-import * as srutil from 'srutil';
+import * as Game from 'game';
 import * as rollStats from 'rollStats';
 
 type Props = {
-    event: Event.Roll
+    +event: Event.RerollFailures,
 }
-function RollRecordInner({ event }: Props, ref) {
+function RerollRecord({ event }: Props, ref) {
     const game = React.useContext(Game.Ctx);
 
     const color = Event.colorOf(event);
@@ -28,34 +28,35 @@ function RollRecordInner({ event }: Props, ref) {
             <UI.HashColored id={event.source.id}>
                 {event.source.name}
             </UI.HashColored>
-            {` rolls`}
+            &nbsp;
+            <b>rerolls failures</b>
         </>
     ) : (
-        <>Rolled</>
+        <b>Rerolled failures</b>
     );
+
     const title = event.title ? (
         <>to <b>{event.title}</b></>
     ) : (
-        <>{event.dice.length} {event.dice.length == 1 ? "die" : "dice"}</>
+        <>on {event.rounds[1].length} dice</>
     );
 
     return (
         <UI.FlexColumn ref={ref}>
-            <UI.FlexRow>
+            <UI.FlexRow alignItems="flex-start">
                 <Roll.Title>{intro} {title}</Roll.Title>
                 <Roll.Results color={color} result={result} />
             </UI.FlexRow>
             <Roll.Scrollable>
-                <dice.List rolls={event.dice} />
+                <dice.List rolls={event.rounds[1]} />
+                <Roll.Rounds icon={icons.faRedo} color={color}
+                             transform="grow-5"
+                             rounds={[event.rounds[0]]} />
             </Roll.Scrollable>
-            <UI.FlexRow floatRight>
+            <UI.FlexRow>
                 <humanTime.Since date={Event.timeOf(event)} />
-                <UI.FlexRow>
-                    {canModify &&
-                        <Roll.ActionsRow event={event} result={result} />}
-                </UI.FlexRow>
             </UI.FlexRow>
         </UI.FlexColumn>
     );
 }
-export const RollRecord = React.memo<Props>(React.forwardRef(RollRecordInner));
+export const Reroll = React.memo<Props>(React.forwardRef(RerollRecord));

--- a/src/record/reroll.js
+++ b/src/record/reroll.js
@@ -1,27 +1,21 @@
 // @flow
 
 import * as React from 'react';
-import styled from 'styled-components/macro';
 import * as UI from 'style';
-import theme from 'style/theme';
 import * as dice from 'dice';
 import * as humanTime from 'humanTime';
 import * as icons from 'style/icon';
 import * as Roll from './rollComponents';
 
 import * as Event from 'event';
-import * as Game from 'game';
 import * as rollStats from 'rollStats';
 
 type Props = {
     +event: Event.RerollFailures,
 }
 function RerollRecord({ event }: Props, ref) {
-    const game = React.useContext(Game.Ctx);
-
     const color = Event.colorOf(event);
     const result = rollStats.results(event);
-    const canModify = Event.canModify(event, game?.player?.id);
 
     const intro: React.Node = event.source !== "local" ? (
         <>
@@ -38,7 +32,7 @@ function RerollRecord({ event }: Props, ref) {
     const title = event.title ? (
         <>to <b>{event.title}</b></>
     ) : (
-        <>on {event.rounds[1].length} dice</>
+        <>on {event.rounds[1].length} {event.rounds[1].length === 1 ? "die" : "dice"}</>
     );
 
     return (

--- a/src/record/roll.js
+++ b/src/record/roll.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as React from 'react';
-import styled from 'styled-components/macro';
 import * as UI from 'style';
 import * as dice from 'dice';
 import * as humanTime from 'humanTime';
@@ -9,8 +8,6 @@ import * as Roll from './rollComponents';
 
 import * as Game from 'game';
 import * as Event from 'event';
-import routes from 'routes';
-import * as srutil from 'srutil';
 import * as rollStats from 'rollStats';
 
 type Props = {
@@ -36,7 +33,7 @@ function RollRecordInner({ event }: Props, ref) {
     const title = event.title ? (
         <>to <b>{event.title}</b></>
     ) : (
-        <>{event.dice.length} {event.dice.length == 1 ? "die" : "dice"}</>
+        <>{event.dice.length} {event.dice.length === 1 ? "die" : "dice"}</>
     );
 
     return (

--- a/src/record/roll.js
+++ b/src/record/roll.js
@@ -26,9 +26,9 @@ function RollActionsRow({edgeActions, onPush, onSecondChance, onRemove}: RollAct
             <UI.LinkButton disabled={!edgeActions} onClick={onSecondChance}>
                 second chance
             </UI.LinkButton>
-            {/*<UI.LinkButton disabled={!onRemove} onClick={onRemove}>
+            <UI.LinkButton disabled={!onRemove} onClick={onRemove}>
                 remove
-            </UI.LinkButton>*/}
+            </UI.LinkButton>
         </UI.LinkList>
     );
 }
@@ -65,8 +65,6 @@ function rollActions(event: Event.DiceEvent, eventIx: number, dispatch: Event.Di
         }
     }
 }
-
-const WrapperColumn = styled(UI.FlexColumn)``;
 
 const TitleRow = styled(UI.FlexRow)`
     flex-grow: 1;
@@ -183,7 +181,7 @@ export const RollRecord = React.memo<RollProps>(function RollRecord({ event, eve
     );
 
     return (
-        <WrapperColumn>
+        <UI.FlexColumn className="returnedFromRoll">
             <RollScrollable>
                 <TitleRow>
                     <UI.NoWrap>{intro} {title}</UI.NoWrap>
@@ -194,6 +192,6 @@ export const RollRecord = React.memo<RollProps>(function RollRecord({ event, eve
             </RollScrollable>
             {canModify && !result.edged &&
                 <RollActionsRow edgeActions={!result.edged} {...actions} />}
-        </WrapperColumn>
+        </UI.FlexColumn>
     );
 });

--- a/src/record/rollComponents.js
+++ b/src/record/rollComponents.js
@@ -1,0 +1,151 @@
+// @flow
+
+import * as React from 'react';
+import styled from 'styled-components/macro';
+import type { StyledComponent } from 'styled-components';
+import * as UI from 'style';
+import * as dice from 'dice';
+
+import type { Connection } from 'connection';
+import * as Event from 'event';
+import * as rollStats from 'rollStats';
+import routes from 'routes';
+import * as srutil from 'srutil';
+
+export const Title: StyledComponent<> = styled.span`
+    white-space: wrap;
+    line-height: 1.2em;
+    flex-grow: 1;
+    padding-left: 2px;
+`;
+
+export const Scrollable: StyledComponent<> = styled(UI.FlexColumn)`
+    overflow-x: auto; /* Left-right scroll */
+    flex-wrap: nowrap;
+    align-content: stretch;
+
+    & > * {
+        flex-basis: max-content;
+        margin-bottom: 4px;
+    }
+    & :last-child {
+        margin-bottom: 0;
+    }
+`;
+
+const StyledResults: StyledComponent<{ color: string }> = styled.b`
+    color: ${props => props.color};
+
+    align-self: flex-start;
+    line-height: 1.2;
+    margin-top: 0;
+    margin-left: auto;
+    padding: 0 4px 0 .5em;
+    justify-content: flex-end;
+    white-space: nowrap;
+`;
+
+type RollMessageProps = {
+    +color: string,
+    +result: rollStats.HitsResults,
+};
+export function Results({ color, result }: RollMessageProps) {
+    const message = rollStats.resultMessage(result);
+    return (
+        <StyledResults color={color}>
+            {message}
+        </StyledResults>
+    )
+}
+
+const RoundsRow = styled(UI.FlexRow)`
+    & > *:first-child {
+        margin: 0 6px;
+    }
+`;
+type RoundsProps = {
+    +rounds: number[][],
+    +icon: any,
+    +color: string,
+    +transform?: string,
+};
+export function Rounds({ rounds, icon, transform, color }: RoundsProps): React.Node {
+    if (rounds.length == 0) {
+        return (
+            <RoundsRow>
+                <UI.FAIcon icon={icon} color={color} className="sr-die"
+                            fixedWidth transform={transform} />
+                <tt>:(</tt>
+            </RoundsRow>
+        );
+    }
+    return (
+        <UI.FlexRow>
+            {rounds.map((rolls, ix) =>
+                <RoundsRow key={ix}>
+                    <UI.FAIcon icon={icon} color={color} className="sr-die"
+                               fixedWidth transform={transform} />
+                    <dice.List rolls={rolls} />
+                </RoundsRow>
+            )}
+        </UI.FlexRow>
+    );
+}
+
+function canSecondChance(result: rollStats.HitsResults) {
+    return !result.edged && result.hits < result.dice.length;
+}
+
+type Props = { event: Event.DiceEvent, result: rollStats.HitsResults };
+function LocalActionsRow({ event, result }: Props) {
+    const dispatch = React.useContext(Event.DispatchCtx);
+
+    const onSecondChance = React.useCallback(function onSecondChance() {
+        if (!event.dice) { return; }
+        const rerolled: Event.RerollFailures = {
+            ty: "rerollFailures",
+            id: Event.newID(),
+            rollID: event.id,
+            title: event.title,
+            source: event.source,
+            rounds: [srutil.rerollFailures(event.dice), event.dice]
+        };
+        dispatch({ ty: "newEvent", event: rerolled });
+    }, [event]);
+
+    return (
+        <UI.LinkList>
+            <UI.LinkButton disabled={!canSecondChance(result)} onClick={onSecondChance}>
+                second chance
+            </UI.LinkButton>
+        </UI.LinkList>
+    );
+}
+
+function GameActionsRow({ event, result }: Props) {
+    const dispatch = React.useContext(Event.DispatchCtx);
+
+    const [connection, setConnection] = React.useState<Connection>("offline");
+    const onSecondChance = React.useCallback(function onSecondChance() {
+        routes.game.reroll({ rollID: event.id, rerollType: "rerollFailures" })
+            .onConnection(setConnection);
+    }, [event]);
+
+    return (
+        <UI.LinkList>
+            <UI.LinkButton onClick={onSecondChance}
+                disabled={!canSecondChance(result) || connection === "connecting"}>
+                second chance
+            </UI.LinkButton>
+        </UI.LinkList>
+    );
+}
+
+export function ActionsRow({ event, result }: Props) {
+    if (event.source === "local") {
+        return (<LocalActionsRow event={event} result={result} />);
+    }
+    else {
+        return (<GameActionsRow event={event} result={result} />);
+    }
+}

--- a/src/record/rollComponents.js
+++ b/src/record/rollComponents.js
@@ -70,7 +70,7 @@ type RoundsProps = {
     +transform?: string,
 };
 export function Rounds({ rounds, icon, transform, color }: RoundsProps): React.Node {
-    if (rounds.length == 0) {
+    if (rounds.length === 0) {
         return (
             <RoundsRow>
                 <UI.FAIcon icon={icon} color={color} className="sr-die"
@@ -111,7 +111,7 @@ function LocalActionsRow({ event, result }: Props) {
             rounds: [srutil.rerollFailures(event.dice), event.dice]
         };
         dispatch({ ty: "newEvent", event: rerolled });
-    }, [event]);
+    }, [event, dispatch]);
 
     return (
         <UI.LinkList>
@@ -123,9 +123,8 @@ function LocalActionsRow({ event, result }: Props) {
 }
 
 function GameActionsRow({ event, result }: Props) {
-    const dispatch = React.useContext(Event.DispatchCtx);
-
     const [connection, setConnection] = React.useState<Connection>("offline");
+
     const onSecondChance = React.useCallback(function onSecondChance() {
         routes.game.reroll({ rollID: event.id, rerollType: "rerollFailures" })
             .onConnection(setConnection);

--- a/src/rollStats.js
+++ b/src/rollStats.js
@@ -52,7 +52,7 @@ export function results(event: Event.DiceEvent): HitsResults {
 }
 
 export function resultMessage(results: HitsResults): string {
-    const hits = results.rerolled ? "total hits" : "hits";
+    const hits = results.hits == 1 ? "hit" : "hits";
     if (results.critical) {
         return "Critical glitch!"
     }

--- a/src/rollStats.js
+++ b/src/rollStats.js
@@ -52,7 +52,7 @@ export function results(event: Event.DiceEvent): HitsResults {
 }
 
 export function resultMessage(results: HitsResults): string {
-    const hits = results.hits == 1 ? "hit" : "hits";
+    const hits = results.hits === 1 ? "hit" : "hits";
     if (results.critical) {
         return "Critical glitch!"
     }

--- a/src/style/icon.js
+++ b/src/style/icon.js
@@ -9,6 +9,8 @@ export {
     faIdBadge, faIdCard, faPortrait, faLock, faKey,
     // Icons for in game/GC/local rolls
     faUser, faUsers, faUserFriends, faUserSecret,
+    // Roll icons
+    faBolt, faRedo,
     // dice
     // faDiceFive, faDiceFour, faDiceOne, faDiceSix, faDiceThree, faDiceTwo,
 } from "@fortawesome/free-solid-svg-icons";

--- a/src/style/layout.js
+++ b/src/style/layout.js
@@ -11,14 +11,19 @@ export const NoWrap: StyledComponent<> = styled.span`
 
 export const FlexRow: StyledComponent<> = styled.div`
     display: flex;
-    align-items: center;
+    align-items: ${props => props.alignItems ? props.alignItems : "center"};
     ${props => props.maxWidth ? 'width: 100%;' : ''}
     ${props => props.flexWrap ? 'flex-wrap: wrap;' : ''}
+
+    & *:last-child {
+        ${props => props.floatRight ? 'margin-left: auto;' : ''}
+    }
 `;
 
 export const FlexColumn: StyledComponent<> = styled.div`
     display: flex;
     flex-direction: column;
+    ${props => props.alignItems ? `align-items: ${props.alignItems};` : ''}
     ${props => props.maxWidth ? 'width: 100%;' : ''}
     ${props => props.flexWrap ? 'flex-wrap: wrap;' : ''}
 `;
@@ -31,12 +36,8 @@ export const ColumnToRow: StyledComponent<{grow?: bool}> = styled(FlexColumn)`
 `;
 
 export const LinkList: StyledComponent<> = styled(FlexRow)`
-    width: 100%;
     & > * {
-        margin-right: 10px;
-    }
-    & :last-child {
-        margin-right: 0em;
+        margin-right: .5em;
     }
 `;
 


### PR DESCRIPTION
Rewrite event records, add timestamps as well


- Refactor `RollRecord` into one for each event type
- Add multiline edge records
- Add `humanTime` for displaying relative timestamps

- Fix bugs with "1 hits" and "1 dice"
- Fix hardcoded record sizes not working on mobile